### PR TITLE
Test rakuten point

### DIFF
--- a/imap.py
+++ b/imap.py
@@ -94,7 +94,8 @@ class MyEmail:
             or ("メールdeポイント" in self.subject and self.subject.count("ポイント") >= 2)
             or "【1ポイントゲット！】" in self.subject
             or "クリックして1ポイント" in self.subject
-        )
+            or "クリックで1ポイント" in self.subject
+            )
         
         return senderchk, subjectchk
 

--- a/imap.py
+++ b/imap.py
@@ -125,12 +125,16 @@ class MyEmail:
                 if "http" in line:
                     if 'href="' in line:  # text/htmlの場合
                         return line.split('"')[1]
+                        self.detected_message = line  # 検出されたメッセージを保持
+                        print(f"URL txt detected: {line}")  # URL検出メッセージを出力
                     return line
                 nexturl = True
             elif nexturl and "http" in line:
                 # 次の行にURLが含まれている場合
                 if 'href="' in line:  # text/htmlの場合
                     return line.split('"')[1]
+                    self.detected_message = line  # 検出されたメッセージを保持
+                    print(f"URL txt2 detected: {line}")  # URL検出メッセージを出力
                 return line
             else:
                 nexturl = False
@@ -150,6 +154,8 @@ class MyEmail:
             if banner_url in line:
                 for u in line.split('"'):
                     if "http" in u and not (".png" in u or ".gif" in u or ".jpg" in u):
+                        self.detected_message = u  # 検出されたメッセージを保持
+                        print(f"URL txt2 detected: {u}")  # URL検出メッセージを出力
                         return u
                 break
         return None

--- a/imap.py
+++ b/imap.py
@@ -125,7 +125,7 @@ class MyEmail:
             print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
-                or 'ドリームくじ' in line
+                or '】ドリームくじ（' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
             elif nexturl and "http" in line:

--- a/imap.py
+++ b/imap.py
@@ -124,8 +124,8 @@ class MyEmail:
         self.retrieveBody()
         nexturl = False
         for line in self.body.splitlines():
-            print(nexturl)
-            print(line)
+            #print(nexturl)
+            #print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line

--- a/imap.py
+++ b/imap.py
@@ -173,6 +173,7 @@ class MyEmail:
                 charset = pref.split('=')[1]
                 break
         self.body = self.bodyFromMsg(self.msg).decode(charset)
+        print(self.body)  # メールの本文を出力
 
     def bodyFromMsg(self, b):
         body = ""

--- a/imap.py
+++ b/imap.py
@@ -149,6 +149,7 @@ class MyEmail:
             return None
         for line in self.body.splitlines():
             if banner_url in line:
+                print(line)
                 for u in line.split('"'):
                     if "http" in u and not (".png" in u or ".gif" in u or ".jpg" in u):
                         self.detected_message = u  # 検出されたメッセージを保持

--- a/imap.py
+++ b/imap.py
@@ -128,7 +128,7 @@ class MyEmail:
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line
-                #or 'ここより下↓に本文コンテンツを入れる' in line
+                or 'ここより下↓に本文コンテンツを入れる' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
             elif nexturl and "http" in line and "href" in line:

--- a/imap.py
+++ b/imap.py
@@ -121,12 +121,12 @@ class MyEmail:
         self.retrieveBody()
         nexturl = False
         for line in self.body.splitlines():
+            print(nexturl)
+            print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line 
                 or 'コンテンツエリア' in line):
                 nexturl = True
-                print(line)
-                print(nexturl)
             elif nexturl and "http" in line:
                 if 'href="' in line:  # text/htmlの場合
                     line = line.split('"')[1]

--- a/imap.py
+++ b/imap.py
@@ -103,15 +103,17 @@ class MyEmail:
             return None
         self.retrieveBody()
         if not "掲載店舗の商品いずれかをクリックしていただいた方" in self.body:
+            print(f"not shop mail")
             return None
 
         for line in self.body.splitlines():
+            print(line)
             if '<tr><td><img' in line and 'href' in line:
                 for u in line.split('"'):
                     if "http" in u and not (".png" in u or ".gif" in u or ".jpg" in u):
                         return u
                 break
-                print(f"no shop")
+        print(f"no shop")
         return None
 
     def tryTextualURL(self):
@@ -126,7 +128,7 @@ class MyEmail:
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line
-                or 'ここより下↓に本文コンテンツを入れる' in line
+                #or 'ここより下↓に本文コンテンツを入れる' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
             elif nexturl and "http" in line:

--- a/imap.py
+++ b/imap.py
@@ -126,6 +126,7 @@ class MyEmail:
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line
+                or 'ここより下↓に本文コンテンツを入れる' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
             elif nexturl and "http" in line:

--- a/imap.py
+++ b/imap.py
@@ -131,7 +131,7 @@ class MyEmail:
                 #or 'ここより下↓に本文コンテンツを入れる' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
-            elif nexturl and "http" in line:
+            elif nexturl and "http" in line and "href" in line:
                 if 'href="' in line:  # text/htmlの場合
                     line = line.split('"')[1]
                     print(f"URL txt detected: {line}")  # URL検出メッセージを出力

--- a/imap.py
+++ b/imap.py
@@ -124,7 +124,8 @@ class MyEmail:
             print(nexturl)
             print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
-                or '▼楽天ポイント獲得はこちら▼' in line 
+                or '▼楽天ポイント獲得はこちら▼' in line
+                or 'ドリームくじ' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
             elif nexturl and "http" in line:

--- a/imap.py
+++ b/imap.py
@@ -123,8 +123,8 @@ class MyEmail:
         self.retrieveBody()
         nexturl = False
         for line in self.body.splitlines():
-            print(nexturl)
-            print(line)
+            #print(nexturl)
+            #print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line

--- a/imap.py
+++ b/imap.py
@@ -118,7 +118,7 @@ class MyEmail:
         self.retrieveBody()
         nexturl = False
         for line in self.body.splitlines():
-            if '↓ クリックでもれなく1ポイントGet!! ↓' in line or '▼楽天ポイント獲得はこちら▼' in line:
+            if '↓ クリックでもれなく1ポイントGet!! ↓' in line or '▼楽天ポイント獲得はこちら▼' in line or '抽せん券1枚GET！' in line:
                 nexturl = True
             elif nexturl and "http" in line:
                 if 'href="' in line: # text/html can contain this as well!!!

--- a/imap.py
+++ b/imap.py
@@ -109,6 +109,7 @@ class MyEmail:
                     if "http" in u and not (".png" in u or ".gif" in u or ".jpg" in u):
                         return u
                 break
+                print(f"no shop")
         return None
 
     def tryTextualURL(self):
@@ -138,6 +139,7 @@ class MyEmail:
                 return line
             else:
                 nexturl = False
+                print(f"no txt")
         return None
 
     def tryBannerURL(self):
@@ -158,6 +160,7 @@ class MyEmail:
                         print(f"URL txt2 detected: {u}")  # URL検出メッセージを出力
                         return u
                 break
+                print(f"no banner")
         return None
     
     def retrieveBody(self):

--- a/imap.py
+++ b/imap.py
@@ -117,24 +117,24 @@ class MyEmail:
         #    return None
         self.retrieveBody()
         nexturl = False
-            for line in self.body.splitlines():
-                if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
-                    or '▼楽天ポイント獲得はこちら▼' in line 
-                    or '抽せん券1枚GET！' in line):
-            # 特定のテキストの行にURLが含まれている場合
-            if "http" in line:
+        for line in self.body.splitlines():
+            if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
+                or '▼楽天ポイント獲得はこちら▼' in line 
+                or '抽せん券1枚GET！' in line):
+                # 特定のテキストの行にURLが含まれている場合
+                if "http" in line:
+                    if 'href="' in line:  # text/htmlの場合
+                        return line.split('"')[1]
+                    return line
+                nexturl = True
+            elif nexturl and "http" in line:
+                # 次の行にURLが含まれている場合
                 if 'href="' in line:  # text/htmlの場合
                     return line.split('"')[1]
                 return line
-            nexturl = True
-        elif nexturl and "http" in line:
-            # 次の行にURLが含まれている場合
-            if 'href="' in line:  # text/htmlの場合
-                return line.split('"')[1]
-            return line
-        else:
-            nexturl = False
-    return None
+            else:
+                nexturl = False
+        return None
 
     def tryBannerURL(self):
         if not "text/html" in self.msg['Content-Type']:

--- a/imap.py
+++ b/imap.py
@@ -132,9 +132,9 @@ class MyEmail:
                     line = line.split('"')[1]
                     print(f"URL txt detected: {line}")  # URL検出メッセージを出力
                 return line
-            else:
-                nexturl = False
-                print(f"no txt")
+            #else:
+                #nexturl = False
+        print(f"no txt")
         return None
 
     def tryBannerURL(self):

--- a/imap.py
+++ b/imap.py
@@ -117,16 +117,24 @@ class MyEmail:
         #    return None
         self.retrieveBody()
         nexturl = False
-        for line in self.body.splitlines():
-            if '↓ クリックでもれなく1ポイントGet!! ↓' in line or '▼楽天ポイント獲得はこちら▼' in line or '抽せん券1枚GET！' in line:
-                nexturl = True
-            elif nexturl and "http" in line:
-                if 'href="' in line: # text/html can contain this as well!!!
-                    line = line.split('"')[1]
+            for line in self.body.splitlines():
+                if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
+                    or '▼楽天ポイント獲得はこちら▼' in line 
+                    or '抽せん券1枚GET！' in line):
+            # 特定のテキストの行にURLが含まれている場合
+            if "http" in line:
+                if 'href="' in line:  # text/htmlの場合
+                    return line.split('"')[1]
                 return line
-            else:
-                nexturl = False
-        return None
+            nexturl = True
+        elif nexturl and "http" in line:
+            # 次の行にURLが含まれている場合
+            if 'href="' in line:  # text/htmlの場合
+                return line.split('"')[1]
+            return line
+        else:
+            nexturl = False
+    return None
 
     def tryBannerURL(self):
         if not "text/html" in self.msg['Content-Type']:

--- a/imap.py
+++ b/imap.py
@@ -120,7 +120,7 @@ class MyEmail:
         for line in self.body.splitlines():
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line 
-                or '抽せん券1枚GET！' in line):
+                or 'コンテンツエリア' in line):
                 # 特定のテキストの行にURLが含まれている場合
                 if "http" in line:
                     if 'href="' in line:  # text/htmlの場合

--- a/imap.py
+++ b/imap.py
@@ -160,7 +160,7 @@ class MyEmail:
                         print(f"URL txt2 detected: {u}")  # URL検出メッセージを出力
                         return u
                 break
-                print(f"no banner")
+        print(f"no banner")
         return None
     
     def retrieveBody(self):

--- a/imap.py
+++ b/imap.py
@@ -124,8 +124,8 @@ class MyEmail:
         self.retrieveBody()
         nexturl = False
         for line in self.body.splitlines():
-            #print(nexturl)
-            #print(line)
+            print(nexturl)
+            print(line)
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line

--- a/imap.py
+++ b/imap.py
@@ -103,7 +103,7 @@ class MyEmail:
         if not "text/html" in self.msg['Content-Type']:
             return None
         self.retrieveBody()
-        if not "期間中に掲載商品のいずれかをクリックしていただいた方" in self.body:
+        if not ("期間中に掲載商品のいずれかをクリックしていただいた方" in self.body or "掲載店舗の商品いずれかをクリックしていただいた方" in self.body):
             print(f"not shop mail")
             return None
 
@@ -126,13 +126,14 @@ class MyEmail:
         for line in self.body.splitlines():
             #print(nexturl)
             #print(line)
+            #下の文字列が見つかってから最初のHTTP かつ src ではない
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line
                 or '】ドリームくじ（' in line
                 or 'ここより下↓に本文コンテンツを入れる' in line
                 or 'コンテンツエリア' in line):
                 nexturl = True
-            elif nexturl and "http" in line and "href" in line:
+            elif nexturl and "http" in line and (not "img src" in line):
                 if 'href="' in line:  # text/htmlの場合
                     line = line.split('"')[1]
                     print(f"URL txt detected: {line}")  # URL検出メッセージを出力

--- a/imap.py
+++ b/imap.py
@@ -19,11 +19,13 @@ import imaplib
 
 interesting_senders = [
     '楽天特典付きキャンペーンニュース <incentive@emagazine.rakuten.co.jp>',
-    '楽天スーパーポイントギャラリーニュース <point-g@emagazine.rakuten.co.jp>',
+    'ポイントインセンティブニュース <point-g@emagazine.rakuten.co.jp>',
     '楽天カレンダーお得なニュース <calendar-info@emagazine.rakuten.co.jp>',
-    'ポイント10倍ニュース <pointo10henbai@emagazine.rakuten.co.jp>',
+    'ポイントお得情報ニュース <pointo10henbai@emagazine.rakuten.co.jp>',
     'メールdeポイント <info@pointmail.rakuten.co.jp>',
     '楽天ダイヤモンド・プラチナ優待ニュース <platinum-news@emagazine.rakuten.co.jp>',
+    '楽天カードショッピングニュース <shopping@mail.rakuten-card.co.jp>',
+    '<info@rcp.rakuten.co.jp>'
 ]
 #not interesting:
 #Infoseek メールdeポイント事務局 <info@pointmail.rakuten.co.jp>
@@ -122,20 +124,13 @@ class MyEmail:
             if ('↓ クリックでもれなく1ポイントGet!! ↓' in line 
                 or '▼楽天ポイント獲得はこちら▼' in line 
                 or 'コンテンツエリア' in line):
-                # 特定のテキストの行にURLが含まれている場合
-                if "http" in line:
-                    if 'href="' in line:  # text/htmlの場合
-                        return line.split('"')[1]
-                        self.detected_message = line  # 検出されたメッセージを保持
-                        print(f"URL txt detected: {line}")  # URL検出メッセージを出力
-                    return line
                 nexturl = True
+                print(line)
+                print(nexturl)
             elif nexturl and "http" in line:
-                # 次の行にURLが含まれている場合
                 if 'href="' in line:  # text/htmlの場合
-                    return line.split('"')[1]
-                    self.detected_message = line  # 検出されたメッセージを保持
-                    print(f"URL txt2 detected: {line}")  # URL検出メッセージを出力
+                    line = line.split('"')[1]
+                    print(f"URL txt detected: {line}")  # URL検出メッセージを出力
                 return line
             else:
                 nexturl = False
@@ -157,7 +152,7 @@ class MyEmail:
                 for u in line.split('"'):
                     if "http" in u and not (".png" in u or ".gif" in u or ".jpg" in u):
                         self.detected_message = u  # 検出されたメッセージを保持
-                        print(f"URL txt2 detected: {u}")  # URL検出メッセージを出力
+                        print(f"URL banner detected: {u}")  # URL検出メッセージを出力
                         return u
                 break
         print(f"no banner")
@@ -173,7 +168,7 @@ class MyEmail:
                 charset = pref.split('=')[1]
                 break
         self.body = self.bodyFromMsg(self.msg).decode(charset)
-        print(self.body)  # メールの本文を出力
+        #print(self.body)  # メールの本文を出力
 
     def bodyFromMsg(self, b):
         body = ""

--- a/imap.py
+++ b/imap.py
@@ -102,7 +102,7 @@ class MyEmail:
         if not "text/html" in self.msg['Content-Type']:
             return None
         self.retrieveBody()
-        if not "掲載店舗の商品いずれかをクリックしていただいた方" in self.body:
+        if not "期間中に掲載商品のいずれかをクリックしていただいた方" in self.body:
             print(f"not shop mail")
             return None
 

--- a/imap.py
+++ b/imap.py
@@ -36,7 +36,7 @@ banner_urls = [
     "://image.infoseek.rakuten.co.jp/content/tmail/htmlmail/maildepoint_btn2.gif",
     "://image.pointmall.rakuten.co.jp/public/special/pointmail/2023/dreamkuji_mail/btn.png",
     "://image.pointmall.rakuten.co.jp/public/special/pointmail/programmatic/mv_300_red.png",
-    "://image.pointmall.rakuten.co.jp/public/special/pointmail/programmatic/mv_300_green.png"
+    "://image.pointmall.rakuten.co.jp/public/special/pointmail/programmatic/mv_300_green.png",
 ]
 
 class MyEmail:


### PR DESCRIPTION
いろいろカスタマイズ。
・GMAILと楽天のアドレスを別にしているため、楽天のアドレスの変数追加。
・対象のメールを追加。サブジェクトを追加
・tryTextureURL内の判定を変更。特定の文字列が見つかってから、次に出現するURL(herf=)を抽出。
    Shopメールと、メールdeポイントに対応。
・デバッグ用に変数の値をprint
